### PR TITLE
Add weather dashboard with horizontal 7-day forecast

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,7 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
+  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Current weather and 7-day forecast.', category: 'Dashboards' },
 ];
 
 // Get unique categories

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,7 +128,12 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
-  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Current weather and 7-day forecast.', category: 'Dashboards' },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Current weather and 7-day forecast.',
+    category: 'Dashboards',
+  },
 ];
 
 // Get unique categories

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -16,9 +16,9 @@ import SegmentedControl from '@cloudscape-design/components/segmented-control';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Spinner from '@cloudscape-design/components/spinner';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
-import Table from '@cloudscape-design/components/table';
 
 import { CustomAppLayout } from '../commons/common-components';
+import '../../styles/weather-dashboard.scss';
 
 // Minimal mapping based on WMO weather codes
 const WEATHER_CODE_MAP: Record<number, string> = {
@@ -300,19 +300,23 @@ export function App() {
           <Container
             header={<Header variant="h2">7-day forecast</Header>}
           >
-            <Table
-              items={dailyRows}
-              columnDefinitions={[
-                { id: 'date', header: 'Date', cell: item => item.date },
-                { id: 'min', header: `Min (${unitLabel})`, cell: item => (item.min !== undefined ? item.min.toFixed(1) : '—') },
-                { id: 'max', header: `Max (${unitLabel})`, cell: item => (item.max !== undefined ? item.max.toFixed(1) : '—') },
-                { id: 'conditions', header: 'Conditions', cell: item => item.description },
-              ]}
-              trackBy="date"
-              resizableColumns
-              stickyHeader
-              empty={<Box variant="p">No forecast available</Box>}
-            />
+            {dailyRows.length === 0 ? (
+              <Box variant="p">No forecast available</Box>
+            ) : (
+              <div className="forecast-strip">
+                {dailyRows.map(item => (
+                  <div key={item.date} className="forecast-card">
+                    <Container header={<Header variant="h3">{item.date}</Header>}>
+                      <SpaceBetween size="xs">
+                        <Box variant="p">Min: {item.min !== undefined ? `${item.min.toFixed(1)} ${unitLabel}` : '—'}</Box>
+                        <Box variant="p">Max: {item.max !== undefined ? `${item.max.toFixed(1)} ${unitLabel}` : '—'}</Box>
+                        <Box variant="p">{item.description}</Box>
+                      </SpaceBetween>
+                    </Container>
+                  </div>
+                ))}
+              </div>
+            )}
           </Container>
 
           <Box variant="p">

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -171,9 +171,12 @@ export function App() {
   };
 
   useEffect(() => {
-    fetchWeather();
+    const handle = setTimeout(() => {
+      fetchWeather();
+    }, 400);
+    return () => clearTimeout(handle);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [units, city, useCustom]);
+  }, [units, city, useCustom, customLat, customLon]);
 
   const dailyRows = useMemo(() => {
     if (!data?.daily) return [] as Array<{ date: string; min?: number; max?: number; code?: number; description: string }>;

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,322 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import FormField from '@cloudscape-design/components/form-field';
+import Grid from '@cloudscape-design/components/grid';
+import Header from '@cloudscape-design/components/header';
+import Input from '@cloudscape-design/components/input';
+import Link from '@cloudscape-design/components/link';
+import Select from '@cloudscape-design/components/select';
+import SegmentedControl from '@cloudscape-design/components/segmented-control';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Table from '@cloudscape-design/components/table';
+
+import { CustomAppLayout } from '../commons/common-components';
+
+// Minimal mapping based on WMO weather codes
+const WEATHER_CODE_MAP: Record<number, string> = {
+  0: 'Clear sky',
+  1: 'Mainly clear',
+  2: 'Partly cloudy',
+  3: 'Overcast',
+  45: 'Fog',
+  48: 'Depositing rime fog',
+  51: 'Light drizzle',
+  53: 'Moderate drizzle',
+  55: 'Dense drizzle',
+  56: 'Light freezing drizzle',
+  57: 'Dense freezing drizzle',
+  61: 'Slight rain',
+  63: 'Moderate rain',
+  65: 'Heavy rain',
+  66: 'Light freezing rain',
+  67: 'Heavy freezing rain',
+  71: 'Slight snow',
+  73: 'Moderate snow',
+  75: 'Heavy snow',
+  77: 'Snow grains',
+  80: 'Slight rain showers',
+  81: 'Moderate rain showers',
+  82: 'Violent rain showers',
+  85: 'Slight snow showers',
+  86: 'Heavy snow showers',
+  95: 'Thunderstorm',
+  96: 'Thunderstorm with slight hail',
+  99: 'Thunderstorm with heavy hail',
+};
+
+function describeWeather(code?: number): string {
+  if (code === undefined || code === null) return '—';
+  return WEATHER_CODE_MAP[code] ?? `Code ${code}`;
+}
+
+type Units = 'celsius' | 'fahrenheit';
+
+type CurrentBlock = {
+  time: string;
+  interval: number;
+  temperature_2m?: number;
+  weather_code?: number;
+  is_day?: number;
+  wind_speed_10m?: number;
+};
+
+interface WeatherResponse {
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  current_units?: Record<string, string>;
+  current?: CurrentBlock;
+  daily_units?: Record<string, string>;
+  daily?: {
+    time: string[];
+    temperature_2m_max?: number[];
+    temperature_2m_min?: number[];
+    weather_code?: number[];
+  };
+}
+
+type CityOption = {
+  label: string;
+  description: string;
+  value: string; // "lat,lon"
+};
+
+const PRESET_CITIES: CityOption[] = [
+  { label: 'San Francisco, US', description: '37.7749, -122.4194', value: '37.7749,-122.4194' },
+  { label: 'New York, US', description: '40.7128, -74.0060', value: '40.7128,-74.0060' },
+  { label: 'London, UK', description: '51.5074, -0.1278', value: '51.5074,-0.1278' },
+  { label: 'Berlin, DE', description: '52.5200, 13.4050', value: '52.5200,13.4050' },
+  { label: 'Tokyo, JP', description: '35.6762, 139.6503', value: '35.6762,139.6503' },
+  { label: 'Sydney, AU', description: '-33.8688, 151.2093', value: '-33.8688,151.2093' },
+];
+
+function parseLatLon(value: string): { lat: number; lon: number } | null {
+  const parts = value.split(',');
+  if (parts.length !== 2) return null;
+  const lat = Number(parts[0].trim());
+  const lon = Number(parts[1].trim());
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+  return { lat, lon };
+}
+
+function buildUrl(lat: number, lon: number, units: Units): string {
+  const params = new URLSearchParams({
+    latitude: String(lat),
+    longitude: String(lon),
+    current: 'temperature_2m,is_day,weather_code,wind_speed_10m',
+    daily: 'temperature_2m_max,temperature_2m_min,weather_code',
+    hourly: 'temperature_2m,precipitation_probability',
+    timezone: 'auto',
+    forecast_days: '7',
+    temperature_unit: units === 'fahrenheit' ? 'fahrenheit' : 'celsius',
+  });
+  return `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
+}
+
+export function App() {
+  const [city, setCity] = useState<CityOption | null>(PRESET_CITIES[0]);
+  const [customLat, setCustomLat] = useState('');
+  const [customLon, setCustomLon] = useState('');
+  const [useCustom, setUseCustom] = useState(false);
+  const [units, setUnits] = useState<Units>('celsius');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<WeatherResponse | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const coords = useMemo(() => {
+    if (useCustom) {
+      const valid = parseLatLon(`${customLat},${customLon}`);
+      return valid;
+    }
+    if (city) return parseLatLon(city.value);
+    return null;
+  }, [useCustom, customLat, customLon, city]);
+
+  const unitLabel = units === 'fahrenheit' ? '°F' : '°C';
+
+  const fetchWeather = async () => {
+    if (!coords) {
+      setError('Enter valid coordinates.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      const url = buildUrl(coords.lat, coords.lon, units);
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const json = (await res.json()) as WeatherResponse;
+      setData(json);
+    } catch (e: any) {
+      if (e?.name !== 'AbortError') {
+        setError(e?.message || 'Failed to load weather');
+        setData(null);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWeather();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [units, city, useCustom]);
+
+  const dailyRows = useMemo(() => {
+    if (!data?.daily) return [] as Array<{ date: string; min?: number; max?: number; code?: number; description: string }>;
+    const { time, temperature_2m_min, temperature_2m_max, weather_code } = data.daily;
+    return time.map((t, i) => ({
+      date: t,
+      min: temperature_2m_min?.[i],
+      max: temperature_2m_max?.[i],
+      code: weather_code?.[i],
+      description: describeWeather(weather_code?.[i]),
+    }));
+  }, [data]);
+
+  return (
+    <CustomAppLayout
+      navigationHide
+      toolsHide
+      content={
+        <SpaceBetween size="l">
+          <Header
+            variant="h1"
+            actions={
+              <SpaceBetween size="xs" direction="horizontal">
+                <Button iconName="external" iconAlign="right" onClick={() => window.open('https://open-meteo.com/en/docs', '_blank')}>
+                  Open-Meteo docs
+                </Button>
+                <Button variant="primary" onClick={fetchWeather} disabled={loading}>
+                  Refresh
+                </Button>
+              </SpaceBetween>
+            }
+          >
+            Weather dashboard
+          </Header>
+
+          <Container header={<Header variant="h2">Location and units</Header>}>
+            <SpaceBetween size="m">
+              <Grid gridDefinition={[{ colspan: { default: 12, m: 8 } }, { colspan: { default: 12, m: 4 } }]}>
+                <FormField label="Select city" description="Choose a preset city or enter custom coordinates.">
+                  <Select
+                    selectedOption={useCustom ? null : city}
+                    onChange={({ detail }) => {
+                      setUseCustom(false);
+                      setCity(detail.selectedOption as CityOption);
+                    }}
+                    options={PRESET_CITIES}
+                    placeholder="Choose city"
+                    controlId="weather-city-select"
+                  />
+                </FormField>
+
+                <FormField label="Units">
+                  <SegmentedControl
+                    selectedId={units}
+                    onChange={({ detail }) => setUnits(detail.selectedId as Units)}
+                    options={[
+                      { id: 'celsius', text: 'Celsius (°C)' },
+                      { id: 'fahrenheit', text: 'Fahrenheit (°F)' },
+                    ]}
+                  />
+                </FormField>
+              </Grid>
+
+              <Grid gridDefinition={[{ colspan: { default: 12, m: 4 } }, { colspan: { default: 12, m: 4 } }, { colspan: { default: 12, m: 4 } }]}>
+                <FormField label="Latitude">
+                  <Input
+                    value={customLat}
+                    onChange={({ detail }) => {
+                      setUseCustom(true);
+                      setCustomLat(detail.value);
+                    }}
+                    placeholder="e.g. 37.7749"
+                  />
+                </FormField>
+                <FormField label="Longitude">
+                  <Input
+                    value={customLon}
+                    onChange={({ detail }) => {
+                      setUseCustom(true);
+                      setCustomLon(detail.value);
+                    }}
+                    placeholder="e.g. -122.4194"
+                  />
+                </FormField>
+                <FormField label=""></FormField>
+              </Grid>
+
+              {coords && (
+                <Box variant="p">
+                  Coordinates: {coords.lat.toFixed(4)}, {coords.lon.toFixed(4)} · Timezone: {data?.timezone ?? '—'}
+                </Box>
+              )}
+            </SpaceBetween>
+          </Container>
+
+          <Container
+            header={<Header variant="h2">Current conditions</Header>}
+          >
+            {loading && (
+              <Box textAlign="center" padding={{ vertical: 'm' }}>
+                <Spinner />
+              </Box>
+            )}
+            {!loading && error && (
+              <StatusIndicator type="error">{error}</StatusIndicator>
+            )}
+            {!loading && !error && (
+              <Grid gridDefinition={[{ colspan: { default: 12, m: 3 } }, { colspan: { default: 12, m: 3 } }, { colspan: { default: 12, m: 3 } }, { colspan: { default: 12, m: 3 } }]}>
+                <Box variant="h3">Temperature</Box>
+                <Box variant="p">{data?.current?.temperature_2m !== undefined ? `${data.current.temperature_2m.toFixed(1)} ${unitLabel}` : '—'}</Box>
+                <Box variant="h3">Wind speed</Box>
+                <Box variant="p">{data?.current?.wind_speed_10m !== undefined ? `${data.current.wind_speed_10m} ${data?.current_units?.wind_speed_10m ?? 'km/h'}` : '—'}</Box>
+                <Box variant="h3">Conditions</Box>
+                <Box variant="p">{describeWeather(data?.current?.weather_code)}</Box>
+                <Box variant="h3">Local time</Box>
+                <Box variant="p">{data?.current?.time ?? '—'}</Box>
+              </Grid>
+            )}
+          </Container>
+
+          <Container
+            header={<Header variant="h2">7-day forecast</Header>}
+          >
+            <Table
+              items={dailyRows}
+              columnDefinitions=[
+                { id: 'date', header: 'Date', cell: item => item.date },
+                { id: 'min', header: `Min (${unitLabel})`, cell: item => (item.min !== undefined ? item.min.toFixed(1) : '—') },
+                { id: 'max', header: `Max (${unitLabel})`, cell: item => (item.max !== undefined ? item.max.toFixed(1) : '—') },
+                { id: 'conditions', header: 'Conditions', cell: item => item.description },
+              ]
+              trackBy="date"
+              resizableColumns
+              stickyHeader
+              empty={<Box variant="p">No forecast available</Box>}
+            />
+          </Container>
+
+          <Box variant="p">
+            Data from <Link href="https://open-meteo.com/" external>Open‑Meteo</Link>. No API key required for typical use.
+          </Box>
+        </SpaceBetween>
+      }
+    />
+  );
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -299,12 +299,12 @@ export function App() {
           >
             <Table
               items={dailyRows}
-              columnDefinitions=[
+              columnDefinitions={[
                 { id: 'date', header: 'Date', cell: item => item.date },
                 { id: 'min', header: `Min (${unitLabel})`, cell: item => (item.min !== undefined ? item.min.toFixed(1) : '—') },
                 { id: 'max', header: `Max (${unitLabel})`, cell: item => (item.max !== undefined ? item.max.toFixed(1) : '—') },
                 { id: 'conditions', header: 'Conditions', cell: item => item.description },
-              ]
+              ]}
               trackBy="date"
               resizableColumns
               stickyHeader

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -179,7 +179,8 @@ export function App() {
   }, [units, city, useCustom, customLat, customLon]);
 
   const dailyRows = useMemo(() => {
-    if (!data?.daily) return [] as Array<{ date: string; min?: number; max?: number; code?: number; description: string }>;
+    if (!data?.daily)
+      return [] as Array<{ date: string; min?: number; max?: number; code?: number; description: string }>;
     const { time, temperature_2m_min, temperature_2m_max, weather_code } = data.daily;
     return time.map((t, i) => ({
       date: t,
@@ -200,7 +201,11 @@ export function App() {
             variant="h1"
             actions={
               <SpaceBetween size="xs" direction="horizontal">
-                <Button iconName="external" iconAlign="right" onClick={() => window.open('https://open-meteo.com/en/docs', '_blank')}>
+                <Button
+                  iconName="external"
+                  iconAlign="right"
+                  onClick={() => window.open('https://open-meteo.com/en/docs', '_blank')}
+                >
                   Open-Meteo docs
                 </Button>
                 <Button variant="primary" onClick={fetchWeather} disabled={loading}>
@@ -240,7 +245,13 @@ export function App() {
                 </FormField>
               </Grid>
 
-              <Grid gridDefinition={[{ colspan: { default: 12, m: 4 } }, { colspan: { default: 12, m: 4 } }, { colspan: { default: 12, m: 4 } }]}>
+              <Grid
+                gridDefinition={[
+                  { colspan: { default: 12, m: 4 } },
+                  { colspan: { default: 12, m: 4 } },
+                  { colspan: { default: 12, m: 4 } },
+                ]}
+              >
                 <FormField label="Latitude">
                   <Input
                     value={customLat}
@@ -272,23 +283,34 @@ export function App() {
             </SpaceBetween>
           </Container>
 
-          <Container
-            header={<Header variant="h2">Current conditions</Header>}
-          >
+          <Container header={<Header variant="h2">Current conditions</Header>}>
             {loading && (
               <Box textAlign="center" padding={{ vertical: 'm' }}>
                 <Spinner />
               </Box>
             )}
-            {!loading && error && (
-              <StatusIndicator type="error">{error}</StatusIndicator>
-            )}
+            {!loading && error && <StatusIndicator type="error">{error}</StatusIndicator>}
             {!loading && !error && (
-              <Grid gridDefinition={[{ colspan: { default: 12, m: 3 } }, { colspan: { default: 12, m: 3 } }, { colspan: { default: 12, m: 3 } }, { colspan: { default: 12, m: 3 } }]}>
+              <Grid
+                gridDefinition={[
+                  { colspan: { default: 12, m: 3 } },
+                  { colspan: { default: 12, m: 3 } },
+                  { colspan: { default: 12, m: 3 } },
+                  { colspan: { default: 12, m: 3 } },
+                ]}
+              >
                 <Box variant="h3">Temperature</Box>
-                <Box variant="p">{data?.current?.temperature_2m !== undefined ? `${data.current.temperature_2m.toFixed(1)} ${unitLabel}` : '—'}</Box>
+                <Box variant="p">
+                  {data?.current?.temperature_2m !== undefined
+                    ? `${data.current.temperature_2m.toFixed(1)} ${unitLabel}`
+                    : '—'}
+                </Box>
                 <Box variant="h3">Wind speed</Box>
-                <Box variant="p">{data?.current?.wind_speed_10m !== undefined ? `${data.current.wind_speed_10m} ${data?.current_units?.wind_speed_10m ?? 'km/h'}` : '—'}</Box>
+                <Box variant="p">
+                  {data?.current?.wind_speed_10m !== undefined
+                    ? `${data.current.wind_speed_10m} ${data?.current_units?.wind_speed_10m ?? 'km/h'}`
+                    : '—'}
+                </Box>
                 <Box variant="h3">Conditions</Box>
                 <Box variant="p">{describeWeather(data?.current?.weather_code)}</Box>
                 <Box variant="h3">Local time</Box>
@@ -297,9 +319,7 @@ export function App() {
             )}
           </Container>
 
-          <Container
-            header={<Header variant="h2">7-day forecast</Header>}
-          >
+          <Container header={<Header variant="h2">7-day forecast</Header>}>
             {dailyRows.length === 0 ? (
               <Box variant="p">No forecast available</Box>
             ) : (
@@ -308,8 +328,12 @@ export function App() {
                   <div key={item.date} className="forecast-card">
                     <Container header={<Header variant="h3">{item.date}</Header>}>
                       <SpaceBetween size="xs">
-                        <Box variant="p">Min: {item.min !== undefined ? `${item.min.toFixed(1)} ${unitLabel}` : '—'}</Box>
-                        <Box variant="p">Max: {item.max !== undefined ? `${item.max.toFixed(1)} ${unitLabel}` : '—'}</Box>
+                        <Box variant="p">
+                          Min: {item.min !== undefined ? `${item.min.toFixed(1)} ${unitLabel}` : '—'}
+                        </Box>
+                        <Box variant="p">
+                          Max: {item.max !== undefined ? `${item.max.toFixed(1)} ${unitLabel}` : '—'}
+                        </Box>
                         <Box variant="p">{item.description}</Box>
                       </SpaceBetween>
                     </Container>
@@ -320,7 +344,11 @@ export function App() {
           </Container>
 
           <Box variant="p">
-            Data from <Link href="https://open-meteo.com/" external>Open‑Meteo</Link>. No API key required for typical use.
+            Data from{' '}
+            <Link href="https://open-meteo.com/" external>
+              Open‑Meteo
+            </Link>
+            . No API key required for typical use.
           </Box>
         </SpaceBetween>
       }

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboardDemo() {
+  return <App />;
+}

--- a/src/styles/weather-dashboard.scss
+++ b/src/styles/weather-dashboard.scss
@@ -11,5 +11,7 @@
 }
 
 @media (max-width: 688px) {
-  .forecast-card { min-width: 160px; }
+  .forecast-card {
+    min-width: 160px;
+  }
 }

--- a/src/styles/weather-dashboard.scss
+++ b/src/styles/weather-dashboard.scss
@@ -1,0 +1,15 @@
+.forecast-strip {
+  display: flex;
+  overflow-x: auto;
+  gap: 12px;
+  padding: 8px 0;
+}
+
+.forecast-card {
+  flex: 0 0 auto;
+  min-width: 200px;
+}
+
+@media (max-width: 688px) {
+  .forecast-card { min-width: 160px; }
+}


### PR DESCRIPTION
## Purpose

The user requested a new weather dashboard using the Open-Meteo API, followed by a request to make the 7-day forecast window display horizontally for better layout and usability.

## Code changes

- **Added weather dashboard page** (`src/pages/weather-dashboard/`) with current weather conditions and 7-day forecast
- **Integrated Open-Meteo API** for fetching weather data without requiring API keys
- **Implemented horizontal forecast layout** using CSS flexbox with responsive design
- **Added location selection** with preset cities and custom coordinate input
- **Added temperature unit toggle** between Celsius and Fahrenheit
- **Added dashboard to main navigation** in the "Dashboards" category
- **Created responsive CSS styling** for forecast cards with mobile optimizationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0960c2a0b48f49f596fd504301958018/pulse-lab)

👀 [Preview Link](https://0960c2a0b48f49f596fd504301958018-pulse-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0960c2a0b48f49f596fd504301958018</projectId>-->
<!--<branchName>pulse-lab</branchName>-->